### PR TITLE
Fixed the broken link to API tokens in the plugin docs page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -79,7 +79,7 @@ connection "pipes" {
 }
 ```
 
-- `token` (required) - [API tokens](https://turbot.com/pipes/docs/profile#tokens) can be used to access the Turbot Pipes API or to connect to Turbot Pipes workspaces from the Steampipe CLI. May alternatively be set via the `STEAMPIPE_CLOUD_TOKEN` or `PIPES_TOKEN`. Note that the value in `STEAMPIPE_CLOUD_TOKEN` will take preference if both are set.
+- `token` (required) - [API tokens](https://turbot.com/pipes/docs/da-settings#tokens) can be used to access the Turbot Pipes API or to connect to Turbot Pipes workspaces from the Steampipe CLI. May alternatively be set via the `STEAMPIPE_CLOUD_TOKEN` or `PIPES_TOKEN`. Note that the value in `STEAMPIPE_CLOUD_TOKEN` will take preference if both are set.
 - `host` (optional) The Turbot Pipes Host URL. This defaults to `https://pipes.turbot.com`. You only need to set this if you are connecting to a remote Turbot Pipes database that is NOT hosted in `https://pipes.turbot.com`. This can also be set via the `STEAMPIPE_CLOUD_HOST` or `PIPES_HOST`. Note that the value in `STEAMPIPE_CLOUD_HOST` will take preference if both are set.
 
 ## Get Involved


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
