### PR TITLE
Update the pipes SDK version to `v0.12.0` and added the column `last_activity_at` to the table pipes_tenant_member, pipes_organization_workspace_member and pipes_organization_member

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/turbot/steampipe-plugin-pipes
 go 1.22.4
 
 require (
-	github.com/turbot/pipes-sdk-go v0.9.0
+	github.com/turbot/pipes-sdk-go v0.12.0-alpha.1
 	github.com/turbot/steampipe-plugin-sdk/v5 v5.10.4
 )
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/turbot/steampipe-plugin-pipes
 go 1.22.4
 
 require (
-	github.com/turbot/pipes-sdk-go v0.12.0-alpha.1
+	github.com/turbot/pipes-sdk-go v0.12.0
 	github.com/turbot/steampipe-plugin-sdk/v5 v5.10.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -558,8 +558,8 @@ github.com/tkrajina/go-reflector v0.5.6 h1:hKQ0gyocG7vgMD2M3dRlYN6WBBOmdoOzJ6njQ
 github.com/tkrajina/go-reflector v0.5.6/go.mod h1:ECbqLgccecY5kPmPmXg1MrHW585yMcDkVl6IvJe64T4=
 github.com/turbot/go-kit v0.10.0-rc.0 h1:kd+jp2ibbIV33Hc8SsMAN410Dl9Pz6SJ40axbKUlSoA=
 github.com/turbot/go-kit v0.10.0-rc.0/go.mod h1:fFQqR59I5z5JeeBLfK1PjSifn4Oprs3NiQx0CxeSJxs=
-github.com/turbot/pipes-sdk-go v0.12.0-alpha.1 h1:QPdREqf23zjYMy0urxL4CEEid4wcIqX+5mwP7kt9EhY=
-github.com/turbot/pipes-sdk-go v0.12.0-alpha.1/go.mod h1:Mb+KhvqqEdRbz/6TSZc2QWDrMa5BN3E4Xw+gPt2TRkc=
+github.com/turbot/pipes-sdk-go v0.12.0 h1:esbbR7bALa5L8n/hqroMPaQSSo3gNM/4X0iTmHa3D6U=
+github.com/turbot/pipes-sdk-go v0.12.0/go.mod h1:Mb+KhvqqEdRbz/6TSZc2QWDrMa5BN3E4Xw+gPt2TRkc=
 github.com/turbot/steampipe-plugin-sdk/v5 v5.10.4 h1:h2Ye0ksL6KN6w2wh1O3mgKthLnyl4QPsTpUj47bRbvc=
 github.com/turbot/steampipe-plugin-sdk/v5 v5.10.4/go.mod h1:FzW+0aq4x1PoCkklCRx43dMrhxk7SYeWVHUb3pNFtFc=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=

--- a/go.sum
+++ b/go.sum
@@ -558,8 +558,8 @@ github.com/tkrajina/go-reflector v0.5.6 h1:hKQ0gyocG7vgMD2M3dRlYN6WBBOmdoOzJ6njQ
 github.com/tkrajina/go-reflector v0.5.6/go.mod h1:ECbqLgccecY5kPmPmXg1MrHW585yMcDkVl6IvJe64T4=
 github.com/turbot/go-kit v0.10.0-rc.0 h1:kd+jp2ibbIV33Hc8SsMAN410Dl9Pz6SJ40axbKUlSoA=
 github.com/turbot/go-kit v0.10.0-rc.0/go.mod h1:fFQqR59I5z5JeeBLfK1PjSifn4Oprs3NiQx0CxeSJxs=
-github.com/turbot/pipes-sdk-go v0.9.0 h1:7RbGZ2qxY13m+9JiHCwL3AFEvBPQBfXkclJDfskrEi8=
-github.com/turbot/pipes-sdk-go v0.9.0/go.mod h1:Mb+KhvqqEdRbz/6TSZc2QWDrMa5BN3E4Xw+gPt2TRkc=
+github.com/turbot/pipes-sdk-go v0.12.0-alpha.1 h1:QPdREqf23zjYMy0urxL4CEEid4wcIqX+5mwP7kt9EhY=
+github.com/turbot/pipes-sdk-go v0.12.0-alpha.1/go.mod h1:Mb+KhvqqEdRbz/6TSZc2QWDrMa5BN3E4Xw+gPt2TRkc=
 github.com/turbot/steampipe-plugin-sdk/v5 v5.10.4 h1:h2Ye0ksL6KN6w2wh1O3mgKthLnyl4QPsTpUj47bRbvc=
 github.com/turbot/steampipe-plugin-sdk/v5 v5.10.4/go.mod h1:FzW+0aq4x1PoCkklCRx43dMrhxk7SYeWVHUb3pNFtFc=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=

--- a/pipes/table_pipes_connection.go
+++ b/pipes/table_pipes_connection.go
@@ -427,9 +427,9 @@ func getIdentityDetailsForConnection(ctx context.Context, d *plugin.QueryData, h
 	var identityId string
 	switch w := h.Item.(type) {
 	case openapi.Connection:
-		identityId = h.Item.(openapi.Connection).IdentityId
+		identityId = *h.Item.(openapi.Connection).IdentityId
 	case *openapi.Connection:
-		identityId = h.Item.(*openapi.Connection).IdentityId
+		identityId = *h.Item.(*openapi.Connection).IdentityId
 	default:
 		plugin.Logger(ctx).Debug("getIdentityDetailsForConnection", "Unknown Type", w)
 	}

--- a/pipes/table_pipes_organization_member.go
+++ b/pipes/table_pipes_organization_member.go
@@ -100,6 +100,11 @@ func tablePipesOrganizationMember(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_TIMESTAMP,
 			},
 			{
+				Name:        "last_activity_at",
+				Description: "The time of the last activity for the member.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
 				Name:        "updated_by_id",
 				Description: "The unique identifier of the user who last updated the member.",
 				Type:        proto.ColumnType_STRING,

--- a/pipes/table_pipes_organization_member.go
+++ b/pipes/table_pipes_organization_member.go
@@ -101,7 +101,7 @@ func tablePipesOrganizationMember(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "last_activity_at",
-				Description: "The time of the last activity for the member.",
+				Description: "Timestamp of the user's most recent activity.",
 				Type:        proto.ColumnType_TIMESTAMP,
 			},
 			{

--- a/pipes/table_pipes_organization_workspace_member.go
+++ b/pipes/table_pipes_organization_workspace_member.go
@@ -98,6 +98,11 @@ func tablePipesOrganizationWorkspaceMember(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_TIMESTAMP,
 			},
 			{
+				Name:        "last_activity_at",
+				Description: "The time of the last activity for the member.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
 				Name:        "created_by_id",
 				Description: "The unique identifier of the user who added the member.",
 				Type:        proto.ColumnType_STRING,

--- a/pipes/table_pipes_organization_workspace_member.go
+++ b/pipes/table_pipes_organization_workspace_member.go
@@ -99,7 +99,7 @@ func tablePipesOrganizationWorkspaceMember(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "last_activity_at",
-				Description: "The time of the last activity for the member.",
+				Description: "Timestamp of the user's most recent activity.",
 				Type:        proto.ColumnType_TIMESTAMP,
 			},
 			{

--- a/pipes/table_pipes_tenant_member.go
+++ b/pipes/table_pipes_tenant_member.go
@@ -82,6 +82,12 @@ func tablePipesTenantMember(_ context.Context) *plugin.Table {
 				Transform:   transform.FromCamel(),
 			},
 			{
+				Name:        "last_activity_at",
+				Description: "The time of the last activity for the member.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromCamel(),
+			},
+			{
 				Name:        "updated_by_id",
 				Description: "The ID of the user that performed the last update.",
 				Type:        proto.ColumnType_STRING,

--- a/pipes/table_pipes_tenant_member.go
+++ b/pipes/table_pipes_tenant_member.go
@@ -67,7 +67,6 @@ func tablePipesTenantMember(_ context.Context) *plugin.Table {
 				Name:        "created_at",
 				Description: "The time of creation in ISO 8601 UTC.",
 				Type:        proto.ColumnType_TIMESTAMP,
-				Transform:   transform.FromCamel(),
 			},
 			{
 				Name:        "created_by_id",
@@ -79,13 +78,11 @@ func tablePipesTenantMember(_ context.Context) *plugin.Table {
 				Name:        "updated_at",
 				Description: "The time of the last update in ISO 8601 UTC.",
 				Type:        proto.ColumnType_TIMESTAMP,
-				Transform:   transform.FromCamel(),
 			},
 			{
 				Name:        "last_activity_at",
-				Description: "The time of the last activity for the member.",
+				Description: "Timestamp of the user's most recent activity.",
 				Type:        proto.ColumnType_TIMESTAMP,
-				Transform:   transform.FromCamel(),
 			},
 			{
 				Name:        "updated_by_id",

--- a/pipes/table_pipes_workspace_aggregator.go
+++ b/pipes/table_pipes_workspace_aggregator.go
@@ -359,7 +359,7 @@ func getUserWorkspaceAggregator(ctx context.Context, d *plugin.QueryData, h *plu
 		return nil, err
 	}
 
-	var aggregator openapi.WorkspaceAggregator
+	var aggregator openapi.Aggregator
 
 	getDetails := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 		aggregator, _, err = svc.UserWorkspaceAggregators.Get(ctx, userHandle, workspaceHandle, aggregatorHandle).Execute()
@@ -372,7 +372,7 @@ func getUserWorkspaceAggregator(ctx context.Context, d *plugin.QueryData, h *plu
 		return nil, err
 	}
 
-	aggregator = response.(openapi.WorkspaceAggregator)
+	aggregator = response.(openapi.Aggregator)
 
 	return aggregator, nil
 }
@@ -385,7 +385,7 @@ func getOrgWorkspaceAggregator(ctx context.Context, d *plugin.QueryData, h *plug
 		return nil, err
 	}
 
-	var aggregator openapi.WorkspaceAggregator
+	var aggregator openapi.Aggregator
 
 	getDetails := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 		aggregator, _, err = svc.OrgWorkspaceAggregators.Get(ctx, orgHandle, workspaceHandle, aggregatorHandle).Execute()
@@ -398,7 +398,7 @@ func getOrgWorkspaceAggregator(ctx context.Context, d *plugin.QueryData, h *plug
 		return nil, err
 	}
 
-	aggregator = response.(openapi.WorkspaceAggregator)
+	aggregator = response.(openapi.Aggregator)
 
 	return aggregator, nil
 }
@@ -461,26 +461,26 @@ func getIdentityWorkspaceDetailsForAggregator(ctx context.Context, d *plugin.Que
 		identityId := h.Item.(openapi.WorkspaceAggregator).IdentityId
 		workspaceId := h.Item.(openapi.WorkspaceAggregator).WorkspaceId
 		getDetails := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-			if strings.HasPrefix(identityId, "u_") {
-				user, _, err := svc.Users.Get(ctx, identityId).Execute()
+			if strings.HasPrefix(*identityId, "u_") {
+				user, _, err := svc.Users.Get(ctx, *identityId).Execute()
 				if err != nil {
 					return nil, err
 				}
 				identityWorkspaceDetails.IdentityType = "user"
 				identityWorkspaceDetails.IdentityHandle = user.Handle
-				workspace, _, err := svc.UserWorkspaces.Get(ctx, identityId, workspaceId).Execute()
+				workspace, _, err := svc.UserWorkspaces.Get(ctx, *identityId, *workspaceId).Execute()
 				if err != nil {
 					return nil, err
 				}
 				identityWorkspaceDetails.WorkspaceHandle = workspace.Handle
 			} else {
-				org, _, err := svc.Orgs.Get(ctx, identityId).Execute()
+				org, _, err := svc.Orgs.Get(ctx, *identityId).Execute()
 				if err != nil {
 					return nil, err
 				}
 				identityWorkspaceDetails.IdentityType = "org"
 				identityWorkspaceDetails.IdentityHandle = org.Handle
-				workspace, _, err := svc.UserWorkspaces.Get(ctx, identityId, workspaceId).Execute()
+				workspace, _, err := svc.UserWorkspaces.Get(ctx, *identityId, *workspaceId).Execute()
 				if err != nil {
 					return nil, err
 				}

--- a/pipes/table_pipes_workspace_pipeline.go
+++ b/pipes/table_pipes_workspace_pipeline.go
@@ -603,26 +603,26 @@ func getIdentityWorkspaceDetailsForPipeline(ctx context.Context, d *plugin.Query
 		identityId := h.Item.(openapi.Pipeline).IdentityId
 		workspaceId := h.Item.(openapi.Pipeline).WorkspaceId
 		getDetails := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-			if strings.HasPrefix(identityId, "u_") {
-				user, _, err := svc.Users.Get(ctx, identityId).Execute()
+			if strings.HasPrefix(*identityId, "u_") {
+				user, _, err := svc.Users.Get(ctx, *identityId).Execute()
 				if err != nil {
 					return nil, err
 				}
 				identityWorkspaceDetails.IdentityType = "user"
 				identityWorkspaceDetails.IdentityHandle = user.Handle
-				workspace, _, err := svc.UserWorkspaces.Get(ctx, identityId, *workspaceId).Execute()
+				workspace, _, err := svc.UserWorkspaces.Get(ctx, *identityId, *workspaceId).Execute()
 				if err != nil {
 					return nil, err
 				}
 				identityWorkspaceDetails.WorkspaceHandle = workspace.Handle
 			} else {
-				org, _, err := svc.Orgs.Get(ctx, identityId).Execute()
+				org, _, err := svc.Orgs.Get(ctx, *identityId).Execute()
 				if err != nil {
 					return nil, err
 				}
 				identityWorkspaceDetails.IdentityType = "org"
 				identityWorkspaceDetails.IdentityHandle = org.Handle
-				workspace, _, err := svc.UserWorkspaces.Get(ctx, identityId, *workspaceId).Execute()
+				workspace, _, err := svc.UserWorkspaces.Get(ctx, *identityId, *workspaceId).Execute()
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION

# Example query results
<details>
  <summary>Results</summary>
  
```
> select  org_handle, user_handle, last_activity_at from pipes_organization_member;
+--------------+---------------------+---------------------------+
| org_handle   | user_handle         | last_activity_at          |
+--------------+---------------------+---------------------------+
| rollout      | partha-thvq         | 2025-01-31T05:30:00+05:30 |
| rollout      | bob-bot             | 2025-01-30T05:30:00+05:30 |
| rollout      | michaelburgess-fjii | 2025-01-23T05:30:00+05:30 |
| product-demo | pritha-ijgc         | 2024-09-26T05:30:00+05:30 |
| product-demo | partha-thvq         | 2025-01-31T05:30:00+05:30 |
| rollout      | graza-io            | 2024-10-25T05:30:00+05:30 |
| product-demo | michaelburgess-fjii | 2025-01-23T05:30:00+05:30 |
| product-demo | victor-ujkk         | 2024-10-29T05:30:00+05:30 |
| rollout      | victor-ujkk         | 2024-10-29T05:30:00+05:30 |
| rollout      | omero-ziwd          | 2024-10-25T05:30:00+05:30 |
| rollout      | siddhartha-nioi     | 2025-01-14T05:30:00+05:30 |
| product-demo | bob-bot             | 2025-01-30T05:30:00+05:30 |
| rollout      | chandrashekar-mbsp  | 2024-10-30T05:30:00+05:30 |
+--------------+---------------------+---------------------------+

Time: 1.2s. Rows returned: 0. Rows fetched: 13. Hydrate calls: 13.

Scans:
  1) pipes_organization_member.pipes: Time: 1.2s. Fetched: 13. Hydrates: 13.


> select  org_handle, user_handle, last_activity_at from pipes_organization_workspace_member;
+--------------+---------------------+---------------------------+
| org_handle   | user_handle         | last_activity_at          |
+--------------+---------------------+---------------------------+
| rollout      | michaelburgess-fjii | 2025-01-23T05:30:00+05:30 |
| rollout      | partha-thvq         | 2025-01-31T05:30:00+05:30 |
| rollout      | victor-ujkk         | 2024-10-29T05:30:00+05:30 |
| product-demo | partha-thvq         | 2025-01-31T05:30:00+05:30 |
| rollout      | graza-io            | 2024-10-25T05:30:00+05:30 |
| product-demo | michaelburgess-fjii | 2025-01-23T05:30:00+05:30 |
| rollout      | bob-bot             | 2025-01-30T05:30:00+05:30 |
| rollout      | chandrashekar-mbsp  | 2024-10-30T05:30:00+05:30 |
| product-demo | pritha-ijgc         | 2024-09-26T05:30:00+05:30 |
| rollout      | siddhartha-nioi     | 2025-01-14T05:30:00+05:30 |
| rollout      | omero-ziwd          | 2024-10-25T05:30:00+05:30 |
| product-demo | victor-ujkk         | 2024-10-29T05:30:00+05:30 |
| product-demo | bob-bot             | 2025-01-30T05:30:00+05:30 |
+--------------+---------------------+---------------------------+

Time: 1.3s. Rows returned: 0. Rows fetched: 13. Hydrate calls: 13.

Scans:
  1) pipes_organization_workspace_member.pipes: Time: 1.3s. Fetched: 13. Hydrates: 13.


> select  id, user_handle, last_activity_at from pipes_tenant_member;
+-------------------------+---------------------+---------------------------+
| id                      | user_handle         | last_activity_at          |
+-------------------------+---------------------+---------------------------+
| tm_cscfo9hgntfmn20fo1hg | victor-ujkk         | 2024-10-29T05:30:00+05:30 |
| tm_crannt2ectftojb36hd0 | pritha-ijgc         | 2024-09-26T05:30:00+05:30 |
| tm_cscfs6kaihe0c4pmn97g | siddhartha-nioi     | 2025-01-14T05:30:00+05:30 |
| tm_cp65fhav0bhh1qq71bk0 | michaelburgess-fjii | 2025-01-23T05:30:00+05:30 |
| tm_csbs2q5vlaisko5u6180 | graza-io            | 2024-10-25T05:30:00+05:30 |
| tm_cphielss8mr5u84vv9v0 | partha-thvq         | 2025-01-31T05:30:00+05:30 |
| tm_cqfavvvukhboj6g8usj0 | bobtusa-pkea        | 2024-07-22T05:30:00+05:30 |
| tm_clscbhgk6pvtj4sh3udg | bob-bot             | 2025-01-30T05:30:00+05:30 |
| tm_cscfq59gntfmn20fo2s0 | chandrashekar-mbsp  | 2024-10-30T05:30:00+05:30 |
| tm_cscqn09gntfmn20fqtb0 | omero-ziwd          | 2024-10-25T05:30:00+05:30 |
+-------------------------+---------------------+---------------------------+

Time: 324ms. Rows returned: 0. Rows fetched: 10. Hydrate calls: 0.

Scans:
  1) pipes_tenant_member.pipes: Time: 304ms. Fetched: 10. Hydrates: 0.
```
</details>
